### PR TITLE
Editorial changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
 					The Working Group will maintain the <a href="https://www.w3.org/TR/pub-manifest/">Publication Manifest</a> and <a href="https://www.w3.org/TR/audiobooks/">Audiobooks</a> Recommendations, and the <a href='https://www.w3.org/TR/lpf/'>Lightweight Packaging Format</a> Note.
 				</p>
 
-				<p>Note: this Working Group is in continuity of the previous <a href='https://www.w3.org/publishing/groups/publ-wg/'>Publishing Working Group</a>, with a similar scope and a reduced focus.</p>
+				<p>Note: this Working Group is a continuation of the previous <a href='https://www.w3.org/publishing/groups/publ-wg/'>Publishing Working Group</a>, with a similar scope and a reduced focus.</p>
 
 				<section id="section-out-of-scope">
 					<h3 id="out-of-scope">Out of Scope</h3>
@@ -281,11 +281,11 @@
 				
 				<aside class='comment'>The CG URL below may have to be updated at the time of finalizing the charter.</aside>
 				<p>
-					This group is expected to coordinate with the <a href='https://www.w3.org/community/publishingcg/'>Publishing Community Group</a> on consensus-based proposals related to content changes for the Audiobooks Working Group Deliverables. The Chairs of this group may choose to reject proposals that are incompatible with this Charter. 
+					This group is expected to coordinate with the <a href='https://www.w3.org/community/publishingcg/'>Publishing Community Group</a> on consensus-based proposals related to content changes for the Audiobooks Working Group Deliverables. The Chairs of this group should reject proposals that are incompatible with this Charter. 
 				</p>
 
         		<p>
-					For all substantive change, this Working Group Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition. The Working Group Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Working Group Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.
+					For all substantive changes, this Working Group Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition. The Working Group Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Working Group Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.
 				</p>
 
         		<p>


### PR DESCRIPTION
Editorial and chairs should (not "may") reject proposals inconsistent with the charter's scope.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks-wg-charter/pull/4.html" title="Last updated on Sep 29, 2020, 5:36 PM UTC (56d348b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks-wg-charter/4/1b6500c...56d348b.html" title="Last updated on Sep 29, 2020, 5:36 PM UTC (56d348b)">Diff</a>